### PR TITLE
fix(security): remove exposed Sentry token

### DIFF
--- a/android/sentry.properties
+++ b/android/sentry.properties
@@ -1,4 +1,3 @@
 defaults.url=https://sentry.io/
 defaults.org=frota
 defaults.project=frota
-auth.token=06202800ec474d328eb0f4f238f40a261b3d43d10c634a56826d20c9b1c72ce7


### PR DESCRIPTION
## Summary

The Android release configuration now contains only non-secret project metadata.

## Details

- Keeps the Sentry URL, organization, and project settings unchanged.
- Release jobs must supply their own Sentry credentials at runtime.

## Testing steps

1. Run:

```sh
! git grep -n '^auth\.token='
```

2. Confirm the command exits successfully without output.
